### PR TITLE
Adding license to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
   "repository": {
     "type": "git",
     "url": "git://https://github.com/IEEEBerkeley/react-ieee.git"
-  }
+  },
+  "license": "CC-BY-NC-ND-4.0"
 }


### PR DESCRIPTION
Added [Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license](https://creativecommons.org/choose/) to package.json

Since our repository is public, it's a good practice to explicitly state our licensing conditions. I chose this license by selecting "No adaptations of our work can be shared" and "No commercial applications" in the link above.

Calling `npm audit fix` also gives a warning if we don't have a license field, which is how I realized this issue.

All it changes is adding a "license" field to package.json. Let me know what you think!